### PR TITLE
add agent container name property #266

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ ecsTaskTemplate(
     containerUser: 'ubuntu',
     remoteFSRoot: '/home/ubuntu',
     overrides: [],
+    agentContainerName: 'java',    
     taskDefinitionOverride: "arn:aws:redacted:redacted:task-definition/${env.task}"
 ) {
   node(dynamic_label) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java
@@ -415,12 +415,23 @@ public class ECSService extends BaseAWSService {
         envNodeSecret.setName("SLAVE_NODE_SECRET");
         envNodeSecret.setValue(agentComputer.getJnlpMac());
 
-        // by convention, we assume the jenkins agent container is the first container in the task definition. ECS requires
-        // all task definitions to contain at least one container, and all containers to have a name, so we do not need
-        // to null- or bounds-check for the presence of a container definition.
-        String agentContainerName = taskDefinition.getContainerDefinitions().get(0).getName();
+        // by convention, unless agent container name is specified, we assume the jenkins agent container is the first
+        // container in the task definition. ECS requires all task definitions to contain at least one container, and
+        // all containers to have a name, so we do not need to null- or bounds-check for the presence of a container
+        // definition.
+        String agentContainerName;
+        if (template.getAgentContainerName() != null) {
+            agentContainerName = template.getAgentContainerName();
 
-        LOGGER.log(Level.FINE, "Found container definition with {0} container(s). Assuming first container is the Jenkins agent: {1}", new Object[]{taskDefinition.getContainerDefinitions().size(), agentContainerName});
+            if (!taskDefinition.getContainerDefinitions().stream().anyMatch(d -> d.getName() == agentContainerName)) {
+                LOGGER.log(Level.SEVERE, "Could not find agent container name: {0} for template: {1}", new Object[] {agentContainerName, template.getDisplayName()});
+                throw new RuntimeException("Could not find agent container name: " + agentContainerName);
+            }
+            LOGGER.log(Level.FINE, "Using the following container name as the Jenkins agent: {0}", agentContainerName);
+        } else {
+            agentContainerName = taskDefinition.getContainerDefinitions().get(0).getName();
+            LOGGER.log(Level.FINE, "Found container definition with {0} container(s). Assuming first container is the Jenkins agent: {1}", new Object[]{taskDefinition.getContainerDefinitions().size(), agentContainerName});
+        }
 
         Tag jenkinsLabelTag = new Tag().withKey(AWS_TAG_JENKINS_LABEL_KEY).withValue(template.getLabel());
         Tag jenkinsTemplateNameTag =

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -111,6 +111,9 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
     @CheckForNull
     private final String label;
 
+    @CheckForNull
+    private final String agentContainerName;
+
     /**
      * Task Definition Override to use, instead of a Jenkins-managed Task definition. May be a family name or an ARN.
      */
@@ -359,6 +362,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
     @DataBoundConstructor
     public ECSTaskTemplate(String templateName,
                            @Nullable String label,
+                           @Nullable String agentContainerName,
                            @Nullable String taskDefinitionOverride,
                            @Nullable String dynamicTaskDefinitionOverride,
                            String image,
@@ -397,6 +401,13 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         // if the user enters a task definition override, always prefer to use it, rather than the jenkins template.
         if (taskDefinitionOverride != null && !taskDefinitionOverride.trim().isEmpty()) {
             this.taskDefinitionOverride = taskDefinitionOverride.trim();
+
+            if (agentContainerName != null && !agentContainerName.trim().isEmpty()) {
+                this.agentContainerName = agentContainerName.trim();
+            } else {
+                this.agentContainerName = null;
+            }
+
             // Always set the template name to the empty string if we are using a task definition override,
             // since we don't want Jenkins to touch our definitions.
             this.templateName = "";
@@ -407,6 +418,9 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
                     "jenkinsTask-" + UUID.randomUUID().toString() : templateName;
             // Make sure we don't have both a template name and a task definition override.
             this.taskDefinitionOverride = null;
+            // An agent container name doesn't make sense when there is only one container
+            // definition.
+            this.agentContainerName = null;
         }
 
         this.label = label;
@@ -526,6 +540,10 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
 
     public String getLabel() {
         return label;
+    }
+
+    public String getAgentContainerName() {
+        return agentContainerName;
     }
 
     public String getTaskDefinitionOverride() {
@@ -761,6 +779,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         }
         String templateName = isNullOrEmpty(this.templateName) ? parent.getTemplateName() : this.templateName;
         String label = isNullOrEmpty(this.label) ? parent.getLabel() : this.label;
+        String agentContainerName = isNullOrEmpty(this.agentContainerName) ? parent.getAgentContainerName() : this.agentContainerName;
         String taskDefinitionOverride = isNullOrEmpty(this.taskDefinitionOverride) ? parent.getTaskDefinitionOverride() : this.taskDefinitionOverride;
         String image = isNullOrEmpty(this.image) ? parent.getImage() : this.image;
         String repositoryCredentials = isNullOrEmpty(this.repositoryCredentials) ? parent.getRepositoryCredentials() : this.repositoryCredentials;
@@ -808,6 +827,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
 
         ECSTaskTemplate merged = new ECSTaskTemplate(templateName,
                                                        label,
+                                                       agentContainerName,
                                                        taskDefinitionOverride,
                                                        null,
                                                        image,
@@ -1504,6 +1524,9 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
         if (label != null ? !label.equals(that.label) : that.label != null) {
             return false;
         }
+        if (agentContainerName != null ? !agentContainerName.equals(that.agentContainerName) : that.agentContainerName != null) {
+            return false;
+        }
         if (taskDefinitionOverride != null ? !taskDefinitionOverride.equals(that.taskDefinitionOverride) : that.taskDefinitionOverride != null) {
             return false;
         }
@@ -1592,6 +1615,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> im
     public int hashCode() {
         int result = templateName.hashCode();
         result = 31 * result + (label != null ? label.hashCode() : 0);
+        result = 31 * result + (agentContainerName != null ? agentContainerName.hashCode() : 0);
         result = 31 * result + (taskDefinitionOverride != null ? taskDefinitionOverride.hashCode() : 0);
         result = 31 * result + (image != null ? image.hashCode() : 0);
         result = 31 * result + (remoteFSRoot != null ? remoteFSRoot.hashCode() : 0);

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSDeclarativeAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSDeclarativeAgent.java
@@ -29,6 +29,7 @@ public class ECSDeclarativeAgent extends DeclarativeAgent<ECSDeclarativeAgent> {
 
     private String label;
     private String cloud;
+    private String agentContainerName;
     private String taskDefinitionOverride;
     private String image;
     private String launchType;
@@ -80,6 +81,16 @@ public class ECSDeclarativeAgent extends DeclarativeAgent<ECSDeclarativeAgent> {
     public void setCloud(String cloud) {
         this.cloud = cloud;
         overrides.add("cloud");
+    }
+
+    public String getAgentContainerName() {
+        return agentContainerName;
+    }
+
+    @DataBoundSetter
+    public void setAgentContainerName(String agentContainerName) {
+        this.agentContainerName = agentContainerName;
+        overrides.add("agentContainerName");
     }
 
     public String getTaskDefinitionOverride() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep.java
@@ -48,6 +48,7 @@ public class ECSTaskTemplateStep extends Step implements Serializable {
     private final String label;
     private final String name;
     private String cloud = DEFAULT_CLOUD;
+    private String agentContainerName;
     private String taskDefinitionOverride;
     private String repositoryCredentials;
     private String image;
@@ -108,6 +109,15 @@ public class ECSTaskTemplateStep extends Step implements Serializable {
 
     public String getCloud() {
         return cloud;
+    }
+
+    @DataBoundSetter
+    public void setAgentContainerName(String agentContainerName) {
+        this.agentContainerName = agentContainerName;
+    }
+
+    public String getAgentContainerName() {
+        return agentContainerName;
     }
 
     @DataBoundSetter

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
@@ -54,6 +54,7 @@ public class ECSTaskTemplateStepExecution extends AbstractStepExecutionImpl {
 
         newTemplate = new ECSTaskTemplate(name,
                                           step.getLabel(),
+                                          step.getAgentContainerName(),
                                           step.getTaskDefinitionOverride(),
                                           null,
                                           step.getImage(),

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -31,6 +31,9 @@
   <f:entry title="${%Template Name}" field="templateName" description="The name that will be appended to the ECS cluster name when creating task definitions. Cannot be used with a Task Definition Override.">
       <f:textbox />
     </f:entry>
+  <f:entry title="${%Agent Container Name}" field="agentContainerName" description="Name of the Jenkins agent container. This is value is only used when Task Definition Override is defined.">
+      <f:textbox />
+  </f:entry>
   <f:entry title="${%Task Definition Override}" field="taskDefinitionOverride" description="Externally-managed ECS task definition to use, instead of creating task definitions using the Template Name. This value takes precedence over all other container settings.">
       <f:textbox />
   </f:entry>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStep/config.jelly
@@ -37,6 +37,9 @@
   <f:entry title="${%Template Name}" field="templateName" description="The name that will be appended to the ECS cluster name when creating task definitions. Cannot be used with a Task Definition Override.">
     <f:textbox />
   </f:entry>
+  <f:entry title="${%Agent Container Name}" field="agentContainerName" description="Name of the Jenkins agent container. This is value is only used when Task Definition Override is defined.">
+    <f:textbox />
+  </f:entry>
   <f:entry title="${%Task Definition Override}" field="taskDefinitionOverride"
     help="/descriptor/com.cloudbees.jenkins.plugins.amazonecs.ECSTaskTemplate/help/externalTaskDefinition"
     description="Externally-managed ECS task definition to use, instead of creating task definitions using the Template Name. This value takes precedence over all other container settings.">

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
@@ -184,6 +184,7 @@ public class ECSCloudTest {
                 templateName,
                 label,
                 "",
+                "",
                 null,
                 "image",
                 "repositoryCredentials",

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
@@ -76,6 +76,7 @@ public class ECSSlaveTest {
         return new ECSTaskTemplate(
             "templateName",
             "label",
+            "agentContainerName",
             "taskDefinitionOverride",
             null,
             "image",

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplateTest.java
@@ -10,7 +10,7 @@ public class ECSTaskTemplateTest {
     ECSTaskTemplate getParent() {
         return new ECSTaskTemplate(
                 "parent-name", "parent-label",
-                null, null, "parent-image", "parent-repository-credentials", "FARGATE", "LINUX", "X86_64",false, null, "parent-network-mode", "parent-remoteFSRoot",
+                null, null, null, "parent-image", "parent-repository-credentials", "FARGATE", "LINUX", "X86_64",false, null, "parent-network-mode", "parent-remoteFSRoot",
                 false, null, 0, 0, 0, null, null, null, false, false,
                 "parent-containerUser", "parent-kernelCapabilities", null, null, null, null, null, null, null, null, null, null, 0, false);
     }
@@ -18,7 +18,7 @@ public class ECSTaskTemplateTest {
     ECSTaskTemplate getChild(String parent) {
         return new ECSTaskTemplate(
                 "child-name", "child-label",
-                null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
+                null, null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
                 false, null, 0, 0, 0, null, null, null, false, false,
                 "child-containerUser", "child-kernelCapabilities", null, null, null, null, null, null, null, null, null, parent, 0, false);
     }
@@ -31,7 +31,7 @@ public class ECSTaskTemplateTest {
 
         ECSTaskTemplate expected = new ECSTaskTemplate(
             "child-name", "child-label",
-            null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
+            null, null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
             false, null, 0, 0, 0, null, null, null, false, false,
             "child-containerUser", "child-kernelCapabilities", null, null, null, null, null, null, null, null, null, null, 0, false);
 
@@ -48,7 +48,7 @@ public class ECSTaskTemplateTest {
 
         ECSTaskTemplate expected = new ECSTaskTemplate(
             "child-name", "child-label",
-            null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
+            null, null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
             false, null, 0, 0, 0, null, null, null, false, false,
             "child-containerUser", "child-kernelCapabilities", null, null, null, null, null, null, null, null, null, null, 0, false);
 
@@ -64,7 +64,7 @@ public class ECSTaskTemplateTest {
 
         ECSTaskTemplate expected = new ECSTaskTemplate(
             "child-name", "child-label",
-            null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
+            null, null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
             false, null, 0, 0, 0, null, null, null, false, false,
             "child-containerUser", "child-kernelCapabilities", null, null, null, null, null, null, null, null, null, null, 0, false);
 
@@ -82,7 +82,7 @@ public class ECSTaskTemplateTest {
 
         ECSTaskTemplate expected = new ECSTaskTemplate(
                 "child-name", "child-label",
-                null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
+                null, null, null, "child-image", "child-repository-credentials", "EC2", "LINUX", "X86_64",false, null, "child-network-mode", "child-remoteFSRoot",
                 false, null, 0, 0, 0, null, null, null, false, false,
                 "child-containerUser", "child-kernelCapabilities", null, null, null, null, null, null, null, null, null, null, 0, false);
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecutionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecutionTest.java
@@ -67,6 +67,7 @@ public class ECSTaskTemplateStepExecutionTest {
                 "template-name",
                 "child-label",
                 UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
                 null,
                 "image-override",
                 UUID.randomUUID().toString(),
@@ -112,6 +113,7 @@ public class ECSTaskTemplateStepExecutionTest {
         step.setLaunchType(expected.getLaunchType());
         step.setOperatingSystemFamily(expected.getOperatingSystemFamily());
         step.setCpuArchitecture(expected.getCpuArchitecture());
+        step.setAgentContainerName(expected.getAgentContainerName());
         step.setTaskDefinitionOverride(expected.getTaskDefinitionOverride());
         step.setRepositoryCredentials(expected.getRepositoryCredentials());
         step.setNetworkMode(expected.getNetworkMode());
@@ -154,6 +156,7 @@ public class ECSTaskTemplateStepExecutionTest {
         return new ECSTaskTemplate(
                 templateName,
                 label,
+                "",
                 "",
                 null,
                 "image",


### PR DESCRIPTION
Implement https://github.com/jenkinsci/amazon-ecs-plugin/issues/266

This exposes a new agentContainerName property on templates. This specifies the name of the container that will be used for the Jenkins agent.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
